### PR TITLE
updates in readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,10 +61,16 @@ Remote Pipeline
 ~~~~~~~~~~~~~~~~~~~~~~
 In this setting, Sioux sends annotation requests to a remote machine. Hence there is not much memory burden on your local machine. Instead all the heavy-lifting is on the remote server. 
 
-**Default remote server:**  This is the default setting in Sioux. The requests are sent to our remote server, hence requires a network connection. This option is here to demonstrate how things work, but it is not a viable solution for your big experiments. If you are a busy nlp user, you should use any of the other options. 
+**Default remote server:**  This is the default setting in Sioux. The requests are sent to our remote server, hence requires a network connection. This option is here to demonstrate how things work, but it is not a viable solution for your big experiments since we limit the number of queries to our serve (current limit is *100 queries a day*). If you are a busy nlp user, you should use any of the other options. 
 
 **Starting your own (remote) server:** If you have a big (remote) machine, this is probably a good option for you. 
-You'll have to read the instructions on how to install the pipeline server in the `pipeline project documentation <https://github.com/CogComp/cogcomp-nlp/tree/master/pipeline#using-pipeline-webserver>`_. In summary, you have to clone our  `Cogcomp-NLP <https://github.com/CogComp/cogcomp-nlp/>`_ java project, and run :code:`pipeline/scripts/runWebserver.sh` to start the server
+You'll have to read the instructions on how to install the pipeline server in the `pipeline project documentation <https://github.com/CogComp/cogcomp-nlp/tree/master/pipeline#using-pipeline-webserver>`_. In summary: 
+
+1. Clone our  `Cogcomp-NLP <https://github.com/CogComp/cogcomp-nlp/>`_ java project. 
+2. Run :code:`pipeline/scripts/runWebserver.sh` to start the server. 
+3. When you see :code:`Server:xxx - Started @xxxxxms`, the server is up and running: 
+  
+After making sure that the server is running, we can make python call to it: 
 
 .. code-block:: python
 
@@ -73,7 +79,6 @@ You'll have to read the instructions on how to install the pipeline server in th
    # constructor declaration: RemotePipeline(server_api = None, file_name = None)
    # "server_api" is the address of the server as string. An example: http://www.fancyUrlName.com:8080
    # "file_name" is the config file used to set up pipeline (optional), please refer the latter section for more details
-
 
 **Note:** This tool is based on CogComp's `pipeline project <https://github.com/CogComp/cogcomp-nlp/tree/master/pipeline>`_. Essentially annotator included in the pipeline should be accessible here. 
  
@@ -85,19 +90,13 @@ To download the models, run the following command:
 
   python -m sioux download
 
-If you have downloaded the models through command :code:`python -m sioux download`, this tool will be running the pipeline locally, with all the annotators disabled. This will downlaod model files into your home directly under `~/.sioux/`. 
-You can verify this in Sioux's config file: :code:`less ~/.sioux/config.cfg`. 
+This will download model files into your home directly under :code:`~/.sioux/`. 
 
 **Note:** Note that downloading the models require you to have Maven installed on your machine. If you don't, `here are some guidelines on how to install it <https://maven.apache.org/install.html>`_. 
 
 **Note:** To use the pipelne locally (A) you have to make sure you have set :code:`JAVA_HOME` variable. In MacOS, you can verify it with :code:`echo "$JAVA_HOME"`. If it is not set, you can :code:`export JAVA_HOME=$(/usr/libexec/java_home)`. 
 
-By default,
-
-* If you have downloaded the models through command :code:`python -m sioux download`, this tool will be running the pipeline locally (A), with all the annotators disabled.
-* If you haven't downloaded the models, it will be communicating with a default remote pipeline server (B.1). 
-
-If you want to change specific behaviors, such as activating or deactivating specific components, you can specify the parameters while initializing local/remote pipeline module.
+In the local pipeline the views are disabled by default. If you want to change specific behaviors, such as activating or deactivating specific components, you can specify the parameters while initializing local/remote pipeline module.
 
 .. code-block:: python
 


### PR DESCRIPTION
 - fix "download" spelling mistake 
 - mentioned that default is limited
 - removed some outdates mentions about default being the local server, after the downloading the models.  
 - pipeline steps for running the remote