### PR TITLE
write text_annotation as json.

### DIFF
--- a/ccg_nlpy/core/text_annotation.py
+++ b/ccg_nlpy/core/text_annotation.py
@@ -19,7 +19,8 @@ class TextAnnotation(object):
         result_json = json.loads(json_str)
 
         self.pipeline = pipeline_instance
-
+        self.corpusId = result_json["corpusId"].strip()
+        self.id = result_json["id"].strip()
         self.text = result_json["text"].strip()
         if len(self.text) <= 0:
             logger.warn("Creating empty TextAnnotation.")
@@ -28,8 +29,8 @@ class TextAnnotation(object):
             self.empty = False
         self.tokens = result_json["tokens"]
         self.score = result_json["sentences"]["score"]
-        self.sentence_end_position = result_json["sentences"][
-            "sentenceEndPositions"]
+        self.sentences = result_json["sentences"]
+        self.sentence_end_position = self.sentences["sentenceEndPositions"]
 
         self.char_offsets = self._extract_char_offset(self.text, self.tokens)
         self.view_dictionary = {}
@@ -279,3 +280,15 @@ class TextAnnotation(object):
     @property
     def get_sentence_end_token_indices(self):
         return self.sentence_end_position
+
+    @property
+    def as_json(self):
+        output = {
+            "corpusId": self.corpusId,
+            "id": self.id,
+            "text": self.text,
+            "tokens": self.tokens,
+            "sentences": self.sentences,
+            "views": [v.as_json for v in self.view_dictionary.values()]
+        }
+        return json.dumps(output)

--- a/ccg_nlpy/core/view.py
+++ b/ccg_nlpy/core/view.py
@@ -42,6 +42,7 @@ class View(object):
 
         # get view_type: TreeView, PredicateArgument, TokenLabelView, ...
         full_type = view["viewData"][0]["viewType"]
+        self.generator = view["viewData"][0]["generator"]
         split_by_period = full_type.split(".")
         self.view_type = split_by_period[len(split_by_period) - 1]
 
@@ -201,3 +202,19 @@ class View(object):
                     (cons['start'] <= start_token_index and cons['end'] >= end_token_index)):
                 view_overlapping_span.append(cons)
         return view_overlapping_span
+
+    @property
+    def as_json(self):
+        output = {
+            "viewName": self.view_name,
+            "viewData": [
+                {
+                    "viewType": self.view_type,
+                    "viewName": self.view_name,
+                    "generator": self.generator,
+                    "score": 1,
+                    "constituents": self.cons_list
+                }
+            ]
+        }
+        return output

--- a/tests/sample_text_annotation.json
+++ b/tests/sample_text_annotation.json
@@ -1,0 +1,224 @@
+{
+  "corpusId": "",
+  "id": "",
+  "text": "\"This is a sample sentence. I\u0027m happy.\"",
+  "tokens": [
+    "\"",
+    "This",
+    "is",
+    "a",
+    "sample",
+    "sentence",
+    ".",
+    "I",
+    "\u0027m",
+    "happy",
+    ".",
+    "\""
+  ],
+  "sentences": {
+    "generator": "TokenizerTextAnnotationBuilder",
+    "score": 1.0,
+    "sentenceEndPositions": [
+      7,
+      12
+    ]
+  },
+  "views": [
+    {
+      "viewName": "MENTION",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView",
+          "viewName": "MENTION",
+          "generator": "org.cogcomp.md.MentionAnnotator",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "PRO-PER",
+              "score": 1.0,
+              "start": 7,
+              "end": 8,
+              "properties": {
+                "EntityHeadEndSpan": "1",
+                "EntityHeadStartSpan": "0",
+                "EntityMentionType": "PRO",
+                "EntityType": "PER"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "POS",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView",
+          "viewName": "POS",
+          "generator": "edu.illinois.cs.cogcomp.pos.POSAnnotator",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": "VBZ",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "TOKENS",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView",
+          "viewName": "TOKENS",
+          "generator": "UserSpecified",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -6,7 +6,7 @@ from ccg_nlpy import TextAnnotation
 
 class TestView(unittest.TestCase):
     def setUp(self):
-        with open('sample_text_annotation.json', 'r') as myfile:
+        with open('tests/sample_text_annotation.json', 'r') as myfile:
             data = myfile.read()
         self.ta = TextAnnotation(json_str=data)
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,14 @@
+import unittest
+import sys
+import os
+
+from ccg_nlpy import TextAnnotation
+
+class TestView(unittest.TestCase):
+    def setUp(self):
+        with open('sample_text_annotation.json', 'r') as myfile:
+            data = myfile.read()
+        self.ta = TextAnnotation(json_str=data)
+
+    def test_print_view(self):
+        print(self.ta.as_json)


### PR DESCRIPTION
Given a `TextAnnotation` object you can now convert it into json by simply calling the `.as_json` method. You can make it a json *string* with: 
```python 
import json
json.dumps(ta.as_json)
```